### PR TITLE
V2/sean/improve upgrade path

### DIFF
--- a/Sources/PhonyKit/Address.swift
+++ b/Sources/PhonyKit/Address.swift
@@ -1,7 +1,6 @@
 import Foundation
 
-// Address
-
+/// Address
 public extension Phony {
     func zipCode(_ format: String? = nil) -> String {
         let format = format ?? self.definitions.postcode.randomElement()!

--- a/Sources/PhonyKit/Commerce.swift
+++ b/Sources/PhonyKit/Commerce.swift
@@ -1,7 +1,7 @@
 // Commerce
 
 public extension Phony {
-    @available(*, deprecated, message: "Use 'productColor()' instead. Will be removed in v3.0.0.")
+    @available(*, deprecated, renamed: "productColor()" , message: "Will be removed in v3.0.0.")
     func color() -> String {
         self.productColor()
     }

--- a/Sources/PhonyKit/Commerce.swift
+++ b/Sources/PhonyKit/Commerce.swift
@@ -1,7 +1,8 @@
-// Commerce
+import Foundation
 
+/// Commerce
 public extension Phony {
-    @available(*, deprecated, renamed: "productColor()" , message: "Will be removed in v3.0.0.")
+    @available(*, deprecated, renamed: "productColor()", message: "Will be removed in v3.0.0.")
     func color() -> String {
         self.productColor()
     }

--- a/Sources/PhonyKit/Company.swift
+++ b/Sources/PhonyKit/Company.swift
@@ -1,5 +1,6 @@
-// Company
+import Foundation
 
+/// Company
 public extension Phony {
     private func suffixes() -> [String] {
         self.definitions.companySuffix

--- a/Sources/PhonyKit/Dates.swift
+++ b/Sources/PhonyKit/Dates.swift
@@ -1,7 +1,6 @@
 import Foundation
 
-// Dates
-
+/// Dates
 public extension Phony {
     private func yearsToSeconds(numberOfYears: Int) -> Double {
         return Double(numberOfYears * 365 * 24 * 3600)

--- a/Sources/PhonyKit/Extensions.swift
+++ b/Sources/PhonyKit/Extensions.swift
@@ -1,4 +1,3 @@
-
 import Foundation
 
 internal extension Character {

--- a/Sources/PhonyKit/Hacker.swift
+++ b/Sources/PhonyKit/Hacker.swift
@@ -1,12 +1,12 @@
+import Foundation
 
-// Hacker
-
+/// Hacker
 public extension Phony {
     @available(*, deprecated, renamed: "hackerAbbreviation()", message: "Will be removed in v3.0.0.")
     func abbreviation() -> String {
         self.hackerAbbreviation()
     }
-    
+
     func hackerAbbreviation() -> String {
         self.definitions.hackerAbbreviation.randomElement()!
     }
@@ -15,7 +15,7 @@ public extension Phony {
     func adjective() -> String {
         self.hackerAdjective()
     }
-    
+
     func hackerAdjective() -> String {
         self.definitions.hackerAdjective.randomElement()!
     }
@@ -24,18 +24,18 @@ public extension Phony {
     func noun() -> String {
         self.hackerNoun()
     }
-    
+
     func hackerNoun() -> String {
         self.definitions.hackerNoun.randomElement()!
     }
 
     @available(*, deprecated, renamed: "hackerVerb()", message: "Will be removed in v3.0.0.")
     func verb() -> String {
-         self.hackerVerb()
+        self.hackerVerb()
     }
 
     func hackerVerb() -> String {
-         self.definitions.hackerVerb.randomElement()!
+        self.definitions.hackerVerb.randomElement()!
     }
 
     @available(*, deprecated, renamed: "hackerIngVerb()", message: "Will be removed in v3.0.0.")

--- a/Sources/PhonyKit/Hacker.swift
+++ b/Sources/PhonyKit/Hacker.swift
@@ -2,7 +2,7 @@
 // Hacker
 
 public extension Phony {
-    @available(*, deprecated, message: "Use 'hackerAbbreviation()' instead. Will be removed in v3.0.0.")
+    @available(*, deprecated, renamed: "hackerAbbreviation()", message: "Will be removed in v3.0.0.")
     func abbreviation() -> String {
         self.hackerAbbreviation()
     }
@@ -11,7 +11,7 @@ public extension Phony {
         self.definitions.hackerAbbreviation.randomElement()!
     }
 
-    @available(*, deprecated, message: "Use 'hackerAdjective()' instead. Will be removed in v3.0.0.")
+    @available(*, deprecated, renamed: "hackerAdjective()", message: "Will be removed in v3.0.0.")
     func adjective() -> String {
         self.hackerAdjective()
     }
@@ -20,7 +20,7 @@ public extension Phony {
         self.definitions.hackerAdjective.randomElement()!
     }
 
-    @available(*, deprecated, message: "Use 'hackerNoun()' instead. Will be removed in v3.0.0.")
+    @available(*, deprecated, renamed: "hackerNoun()", message: "Will be removed in v3.0.0.")
     func noun() -> String {
         self.hackerNoun()
     }
@@ -29,7 +29,7 @@ public extension Phony {
         self.definitions.hackerNoun.randomElement()!
     }
 
-    @available(*, deprecated, message: "Use 'hackerVerb()' instead. Will be removed in v3.0.0.")
+    @available(*, deprecated, renamed: "hackerVerb()", message: "Will be removed in v3.0.0.")
     func verb() -> String {
          self.hackerVerb()
     }
@@ -38,7 +38,7 @@ public extension Phony {
          self.definitions.hackerVerb.randomElement()!
     }
 
-    @available(*, deprecated, message: "Use 'hackerIngVerb()' instead. Will be removed in v3.0.0.")
+    @available(*, deprecated, renamed: "hackerIngVerb()", message: "Will be removed in v3.0.0.")
     func ingverb() -> String {
         self.hackerIngVerb()
     }
@@ -47,7 +47,7 @@ public extension Phony {
         self.definitions.hackerIngVerb.randomElement()!
     }
 
-    @available(*, deprecated, message: "Use 'hackerPhrase()' instead. Will be removed in v3.0.0.")
+    @available(*, deprecated, renamed: "hackerPhrase()", message: "Will be removed in v3.0.0.")
     func phrase() -> String {
         self.hackerPhrase()
     }

--- a/Sources/PhonyKit/Helpers.swift
+++ b/Sources/PhonyKit/Helpers.swift
@@ -1,5 +1,6 @@
-// Helpers
+import Foundation
 
+/// Helpers
 public extension Phony {
     func slugify(str: String) -> String {
         str.replacingOccurrences(of: " ", with: "-").trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/PhonyKit/Images.swift
+++ b/Sources/PhonyKit/Images.swift
@@ -1,8 +1,6 @@
-
 import Foundation
 
-// Images
-
+/// Images
 public extension Phony {
     enum UnsplashCategory: String, CaseIterable {
         case buildings

--- a/Sources/PhonyKit/Internet.swift
+++ b/Sources/PhonyKit/Internet.swift
@@ -1,7 +1,6 @@
 import Foundation
 
-// Internet
-
+/// Internet
 public extension Phony {
     func email(firstName: String? = nil, lastName: String? = nil, provider: String = ["gmail.com", "yahoo.com", "hotmail.com"].randomElement()!) -> String {
         self.slugify(str: self.userName(firstName: firstName, lastName: lastName)) + "@" + provider

--- a/Sources/PhonyKit/Lorem.swift
+++ b/Sources/PhonyKit/Lorem.swift
@@ -1,8 +1,8 @@
+import Foundation
 
-// Lorem
-
+/// Lorem
 public extension Phony {
-    @available(*, deprecated, renamed: "loremWord()",  message: "Will be removed in v3.0.0.")
+    @available(*, deprecated, renamed: "loremWord()", message: "Will be removed in v3.0.0.")
     func word() -> String {
         self.loremWord()
     }
@@ -25,7 +25,7 @@ public extension Phony {
         let sentence = self.words(Int.random(in: 3...10))
         return "\(sentence.prefix(1).uppercased())\(sentence.lowercased().dropFirst())."
     }
-    
+
     func loremSentence() -> String {
         let sentence = self.loremWords(Int.random(in: 3...10))
         return "\(sentence.prefix(1).uppercased())\(sentence.lowercased().dropFirst())."
@@ -67,7 +67,7 @@ public extension Phony {
         (1...paragraphCount).map { _ in self.loremParagraph() }.joined(separator: separator).trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    @available(*, deprecated, renamed: "loremText()",  message: "Will be removed in v3.0.0.")
+    @available(*, deprecated, renamed: "loremText()", message: "Will be removed in v3.0.0.")
     func text() -> String {
         self.loremText()
     }

--- a/Sources/PhonyKit/Lorem.swift
+++ b/Sources/PhonyKit/Lorem.swift
@@ -2,7 +2,7 @@
 // Lorem
 
 public extension Phony {
-    @available(*, deprecated, message: "Use 'loremWord()' instead. Will be removed in v3.0.0.")
+    @available(*, deprecated, renamed: "loremWord()",  message: "Will be removed in v3.0.0.")
     func word() -> String {
         self.loremWord()
     }
@@ -11,7 +11,7 @@ public extension Phony {
         self.definitions.lorem.randomElement()!
     }
 
-    @available(*, deprecated, message: "Use 'loremWords()' instead. Will be removed in v3.0.0.")
+    @available(*, deprecated, renamed: "loremWords()", message: "Will be removed in v3.0.0.")
     func words(_ num: Int = 3, _ separator: String = " ") -> String {
         self.loremWords(num, separator)
     }
@@ -20,7 +20,7 @@ public extension Phony {
         (1...num).map { _ in self.loremWord() }.joined(separator: separator).trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    @available(*, deprecated, message: "Use 'loremSentence()' instead. Will be removed in v3.0.0.")
+    @available(*, deprecated, renamed: "loremSentence()", message: "Will be removed in v3.0.0.")
     func sentence() -> String {
         let sentence = self.words(Int.random(in: 3...10))
         return "\(sentence.prefix(1).uppercased())\(sentence.lowercased().dropFirst())."
@@ -31,7 +31,7 @@ public extension Phony {
         return "\(sentence.prefix(1).uppercased())\(sentence.lowercased().dropFirst())."
     }
 
-    @available(*, deprecated, message: "Use 'loremSlug()' instead. Will be removed in v3.0.0.")
+    @available(*, deprecated, renamed: "loremSlug()", message: "Will be removed in v3.0.0.")
     func slug(wordCount: Int = 3) -> String {
         self.loremSlug(wordCount: wordCount)
     }
@@ -40,7 +40,7 @@ public extension Phony {
         self.slugify(str: self.loremWords(wordCount))
     }
 
-    @available(*, deprecated, message: "Use 'loremSentences()' instead. Will be removed in v3.0.0.")
+    @available(*, deprecated, renamed: "loremSentences()", message: "Will be removed in v3.0.0.")
     func sentences(_ sentenceCount: Int = Int.random(in: 2...6), _ separator: String = " ") -> String {
         self.loremSentences(sentenceCount, separator)
     }
@@ -49,7 +49,7 @@ public extension Phony {
         (1...sentenceCount).map { _ in self.loremSentence() }.joined(separator: separator).trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    @available(*, deprecated, message: "Use 'loremParagraph()' instead. Will be removed in v3.0.0.")
+    @available(*, deprecated, renamed: "loremParagraph()", message: "Will be removed in v3.0.0.")
     func paragraph(_ sentenceCount: Int = 3, _ separator: String = " ") -> String {
         self.loremParagraph(sentenceCount, separator)
     }
@@ -58,7 +58,7 @@ public extension Phony {
         self.loremSentences(sentenceCount, separator)
     }
 
-    @available(*, deprecated, message: "Use 'loremParagraphs()' instead. Will be removed in v3.0.0.")
+    @available(*, deprecated, renamed: "loremParagraphs()", message: "Will be removed in v3.0.0.")
     func paragraphs(_ paragraphCount: Int = 3, _ separator: String = "\n \r") -> String {
         self.loremParagraphs(paragraphCount, separator)
     }
@@ -67,7 +67,7 @@ public extension Phony {
         (1...paragraphCount).map { _ in self.loremParagraph() }.joined(separator: separator).trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    @available(*, deprecated, message: "Use 'loremText()' instead. Will be removed in v3.0.0.")
+    @available(*, deprecated, renamed: "loremText()",  message: "Will be removed in v3.0.0.")
     func text() -> String {
         self.loremText()
     }
@@ -91,7 +91,7 @@ public extension Phony {
         }
     }
 
-    @available(*, deprecated, message: "Use 'loremLines()' instead. Will be removed in v3.0.0.")
+    @available(*, deprecated, renamed: "loremLines()", message: "Will be removed in v3.0.0.")
     func lines(_ lineCount: Int = Int.random(in: 1...5), _ separator: String = "\n") -> String {
         self.loremLines(lineCount, separator)
     }

--- a/Sources/PhonyKit/Name.swift
+++ b/Sources/PhonyKit/Name.swift
@@ -1,6 +1,6 @@
+import Foundation
 
-// Name
-
+/// Name
 public extension Phony {
     enum Gender {
         case male, female

--- a/Sources/PhonyKit/PhoneNumber.swift
+++ b/Sources/PhonyKit/PhoneNumber.swift
@@ -1,8 +1,9 @@
+import Foundation
 
-// PhoneNumber
+/// PhoneNumber
 public extension Phony {
     func phoneNumber(format: String? = nil) -> String {
-         self.replaceSymbolWithNumber(string: format ?? self.phoneFormat())
+        self.replaceSymbolWithNumber(string: format ?? self.phoneFormat())
     }
 
     func phoneNumber(index: Int = 0) -> String {

--- a/Sources/PhonyKit/Phony.swift
+++ b/Sources/PhonyKit/Phony.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public class Phony {
     public static var `default`: Phony = .init(definitions: .default)
 
@@ -10,7 +12,7 @@ public class Phony {
     public func setDefinitions(to type: DefinitionsType) {
         self.definitions = type.definitions
     }
-    
+
     @available(*, deprecated, renamed: "default.setDefinitions(to:)", message: "Will be removed in v3.0.0")
     public static func setDefaultDefinitions(to type: DefinitionsType) {
         Phony.default.setDefinitions(to: type)

--- a/Sources/PhonyKit/Random.swift
+++ b/Sources/PhonyKit/Random.swift
@@ -1,7 +1,6 @@
 import Foundation
 
-// Random
-
+/// Random
 public extension Phony {
     func dictionaryElement<T>(dictionary: [String: T]) -> T? {
         let key = dictionary.keys.sorted().randomElement() ?? ""

--- a/Sources/PhonyKit/Video.swift
+++ b/Sources/PhonyKit/Video.swift
@@ -1,8 +1,6 @@
-
 import Foundation
 
-// Video
-
+/// Video
 public extension Phony {
     func video() -> String {
         self.definitions.videoUris.randomElement()!


### PR DESCRIPTION
Leverages Swift's `renamed` helper to enable Xcode's "Fix It" so migrating is easier.